### PR TITLE
Piped args default to no-ops for `run` and `list`

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,8 +6,8 @@ _What has changed? This should match `CHANGELOG.md`._
 
 ## Before asking for a review
 
-- [ ] Target branch is `master`
-- [ ] [`[Unreleased]`](../blob/master/CHANGELOG.md#unreleased) section in [CHANGELOG.md](../blob/master/CHANGELOG.md) is updated.
+- [ ] Target branch is `main`
+- [ ] [`[Unreleased]`](../blob/main/CHANGELOG.md#unreleased) section in [CHANGELOG.md](../blob/main/CHANGELOG.md) is updated.
 - [ ] I reviewed the "Files changed" tab and self-annotated anything unexpected.
 
 ## Before review (reviewer)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@ Types of changes are:
 * **Fixed** for any bug fixes.
 
 ## [Unreleased]
-
+### Changed
+* `run` and `list` are now no-ops when input is piped to the command, and no arguments are provided. Behaviour when providing regular arguments is unchanged. This makes these commands easier to chain in scripts. E.g.
+  - `workspace reverse | workspace run` will not run any commands
+  - `workspace run` will still run a command in every project
 
 ## [0.1.0] - 2021-11-01
 ### Added

--- a/tests/cli/commands/test_list.py
+++ b/tests/cli/commands/test_list.py
@@ -83,3 +83,18 @@ Dependencies: []
                 "depends_on": [],
             },
         ]
+
+    @staticmethod
+    def should_have_different_default_behaviour_for_pipes():
+        # GIVEN I have two projects
+        paths = {"libs/my-library", "libs/my-other-library"}
+        for path in paths:
+            run(["workspace", "new", "--type", "poetry", path])
+        # THEN workspace list shows all libs with no args or pipe
+        assert run("workspace list --output names").stdout.splitlines() == ["my-library", "my-other-library"]
+        # AND workspace list shows specified project when provided as arg
+        assert run(["workspace", "list", "--output", "names", "my-library"]).stdout.splitlines() == ["my-library"]
+        # AND workspace list shows specified project when provided via pipe
+        assert run("workspace reverse libs/my-library/foo | workspace list --output names").stdout.splitlines() == ["my-library"]
+        # AND workspace list shows nothing when empty input is provided via pipe
+        assert run("workspace reverse some/path | workspace list --output names").stdout.splitlines() == []

--- a/tests/cli/commands/test_remove.py
+++ b/tests/cli/commands/test_remove.py
@@ -10,7 +10,7 @@ class TestRemove:
         # WHEN I remove the project
         run(["workspace", "remove", "my-library"])
         # THEN the project should no longer be tracked
-        assert run(["workspace", "list", "--output", "names"]).text == ""
+        assert run(["workspace", "list", "--output", "names"]).stdout == ""
         # AND the project should still exist
         assert (WORKSPACE_ROOT / path).exists()
 
@@ -22,7 +22,7 @@ class TestRemove:
         # WHEN I remove the project
         run(["workspace", "remove", "my-library", "--delete"])
         # THEN the project should no longer be tracked
-        assert run(["workspace", "list", "--output", "names"]).text == ""
+        assert run(["workspace", "list", "--output", "names"]).stdout == ""
         # AND the project should still exist
         assert not (WORKSPACE_ROOT / path).exists()
 

--- a/workspace/cli/commands/list.py
+++ b/workspace/cli/commands/list.py
@@ -26,12 +26,12 @@ def list_(specifiers: Tuple[str, ...], output: str = "default"):
     """List projects tracked in the workspace."""
     workspace = Workspace.from_path()
 
+    target_set = set(workspace.projects) if click.get_text_stream("stdin").isatty() else set()
     if specifiers:
         target_set = resolve_specifiers(workspace, specifiers)
-    else:
-        target_set = set(workspace.projects)
 
     if not target_set:
+        theme.echo("<w>No projects selected.</w>")
         sys.exit(0)
 
     for name in sorted(target_set):

--- a/workspace/cli/commands/run.py
+++ b/workspace/cli/commands/run.py
@@ -35,10 +35,9 @@ def run(specifiers: Tuple[str], command: str, parallel: bool = False):
     """
     workspace = Workspace.from_path()
 
+    target_set = set(workspace.projects) if click.get_text_stream("stdin").isatty() else set()
     if specifiers:
-        target_set = resolve_specifiers(workspace, set(specifiers))
-    else:
-        target_set = set(workspace.projects)
+        target_set = resolve_specifiers(workspace, specifiers)
 
     if not target_set:
         theme.echo("<w>No projects selected.</w>")


### PR DESCRIPTION
Any related Github Issues?: none

* `run` and `list` are now no-ops when input is piped to the command, and no arguments are provided. Behaviour when providing regular arguments is unchanged. This makes these commands easier to chain in scripts. E.g.
  - `workspace reverse | workspace run` will not run any commands
  - `workspace run` will still run a command in every project

# Check list

## Before asking for a review

- [x] Target branch is `main`
- [x] [`[Unreleased]`](../blob/main/CHANGELOG.md#unreleased) section in [CHANGELOG.md](../blob/main/CHANGELOG.md) is updated.
- [x] I reviewed the "Files changed" tab and self-annotated anything unexpected.

## Before review (reviewer)

- [x] All of the above are checked and true. **Review ALL items.** If not, return the PR to the author.
- [x] Continuous Integration is passing. If not, return the PR to the author.

## After merge (reviewer)

- [ ] Any issues that may now be closed are closed.
