### PR TITLE
Remove extra period

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Types of changes are:
 * **Fixed** for any bug fixes.
 
 ## [Unreleased]
+### Fixed
+* Removed extra period in an error message.
 
 
 ## [0.3.0] - 2021-12-02

--- a/workspace/cli/commands/new.py
+++ b/workspace/cli/commands/new.py
@@ -63,7 +63,7 @@ Specify a different name with:
     if template and template not in workspace.templates:
         template_list = "\n".join([f"  - <a>{path.name}</a>" for path in workspace.templates])
         raise WorkspaceCLIError(
-            f"""<e>Unknown template <b>{template}</b>.</e>.
+            f"""<e>Unknown template <b>{template}</b>.</e>
 
 Available templates are:
 {template_list}


### PR DESCRIPTION
I noticed this when creating a new project from a template that didn't exist.

# Check list

## Before asking for a review

- [x] Target branch is `main`
- [x] [`[Unreleased]`](../blob/main/CHANGELOG.md#unreleased) section in [CHANGELOG.md](../blob/main/CHANGELOG.md) is updated.
- [x] I reviewed the "Files changed" tab and self-annotated anything unexpected.

## Before review (reviewer)

- [x] All of the above are checked and true. **Review ALL items.** If not, return the PR to the author.
- [x] Continuous Integration is passing. If not, return the PR to the author.

## After merge (reviewer)

- [ ] Any issues that may now be closed are closed.
