### PR TITLE
Avoid attempting to parse subprocess output using the theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Types of changes are:
 ## [Unreleased]
 ### Fixed
 * Removed extra period in an error message.
-
+* Don't attempt to parse subprocess output according to theme. Add helpers for escaping text before formatting.
 
 ## [0.3.0] - 2021-12-02
 ### Added

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Install dependencies:
 ```shell
 pyenv shell 3.8.6  # Or other version >= 3.8
 pre-commit install  # Configure commit hooks
-poetry install  # Install Python dependencies
+poetry install -E poetry -E pipenv -E cookiecutter  # Install Python dependencies
 ```
 
 Run tests:

--- a/tests/cli/commands/test_add.py
+++ b/tests/cli/commands/test_add.py
@@ -56,7 +56,7 @@ class TestAdd:
         # THEN the exit code is 1
         assert exc.returncode == 1, exc.text
         # AND the expected error message is displayed
-        assert exc.text.startswith("No adapter of type 'notatype' registered.")
+        assert exc.text.startswith("No adapter of type 'notatype' registered."), exc.text
 
     @staticmethod
     def should_fail_when_type_is_unspecified_and_undetectable():

--- a/tests/cli/test_theme.py
+++ b/tests/cli/test_theme.py
@@ -60,6 +60,5 @@ Raw <b>text</b> can be escaped.
         )
 
     @staticmethod
-    def should_fail_for_unknown_token():
-        with pytest.raises(AssertionError):
-            colorize("<foo>bar</foo>")
+    def should_ignore_unknown_token():
+        assert colorize("<foo>bar</foo>") == "<foo>bar</foo>\x1b[0m"

--- a/tests/cli/test_theme.py
+++ b/tests/cli/test_theme.py
@@ -1,5 +1,3 @@
-import pytest
-
 from workspace.cli.theme import colorize, escape, strip_tags, unescape
 
 

--- a/tests/cli/test_theme.py
+++ b/tests/cli/test_theme.py
@@ -1,12 +1,20 @@
 import pytest
 
-from workspace.cli.theme import colorize, strip_tags
+from workspace.cli.theme import colorize, escape, strip_tags, unescape
+
+
+def test_escape():
+    assert escape("hello, <b>foo</b> bar") == "hello, \<b>foo\</b> bar"
+
+
+def test_unescape():
+    assert unescape("hello, \<b>foo\</b> bar") == "hello, <b>foo</b> bar"
 
 
 class TestColorize:
     @staticmethod
     def should_convert_tags_to_escape_code():
-        text = """<h><b>This is a header</b></h>
+        text = f"""<h><b>This is a header</b></h>
 
 This is some regular text, with <a>accented</a> parts.
 
@@ -16,6 +24,7 @@ Let's draw attention to the <s>good</s> things.
 
 <e>Something here has gone <b>very wrong</b>!</e>
 
+{escape("Raw <b>text</b> can be escaped.")}
 """
         output = colorize(text)
         assert (
@@ -30,6 +39,7 @@ Let's draw attention to the \x1b[38;5;107mgood\x1b[0m things.
 
 \x1b[38;5;167mSomething here has gone \x1b[1mvery wrong\x1b[0m\x1b[38;5;167m!\x1b[0m
 
+Raw <b>text</b> can be escaped.
 \x1b[0m"""
         )
 
@@ -45,6 +55,7 @@ This is something to watch out for!
 
 Something here has gone very wrong!
 
+Raw <b>text</b> can be escaped.
 """
         )
 

--- a/workspace/cli/__init__.py
+++ b/workspace/cli/__init__.py
@@ -37,5 +37,5 @@ def run_cli():
         theme.echo(exc.display)
         sys.exit(exc.exit_code)
     except WorkspaceBaseError as exc:
-        theme.echo(f"<e>{exc}</e>")
+        theme.echo(f"<e>{theme.escape(str(exc))}</e>")
         sys.exit(1)

--- a/workspace/cli/runner.py
+++ b/workspace/cli/runner.py
@@ -2,6 +2,8 @@ import time
 from itertools import cycle
 from typing import Dict, Iterable, List, NamedTuple, Tuple
 
+import click
+
 from workspace.cli import theme
 from workspace.core.models import Project
 
@@ -71,7 +73,7 @@ def _run_in_parallel(project_commands: List[Tuple[Project, str]]) -> int:
     for name, result in complete.items():
         if not result.success:
             theme.echo(f"<e><b>{name}</b> failed with exit code <b>{exit_code}</b></e>:")
-            theme.echo(result.output)
+            click.echo(result.output)  # Don't try to format subprocess output
 
     return _get_exit_code({result.exit_code for result in complete.values()})
 


### PR DESCRIPTION
Any related Github Issues?: 

### Fixed
* Don't attempt to parse subprocess output according to theme. Add helpers for escaping text before formatting.

# Check list

## Before asking for a review

- [x] Target branch is `main`
- [x] [`[Unreleased]`](../blob/main/CHANGELOG.md#unreleased) section in [CHANGELOG.md](../blob/main/CHANGELOG.md) is updated.
- [x] I reviewed the "Files changed" tab and self-annotated anything unexpected.

## Before review (reviewer)

- [ ] All of the above are checked and true. **Review ALL items.** If not, return the PR to the author.
- [ ] Continuous Integration is passing. If not, return the PR to the author.

## After merge (reviewer)

- [ ] Any issues that may now be closed are closed.
